### PR TITLE
Remove deprecated parameter TTL from ES requests

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -413,7 +413,6 @@ class Result implements \JsonSerializable {
                 'index' => 'lookup_tables',
                 'type' => 'esq_lookup',
                 'id' => $id,
-                'ttl' => '1m',
                 'body' => $doc
             ]);
 


### PR DESCRIPTION
Hello, request parameter TTL was deprecated long time ago. Sinse ES 6.4 it is no longer acceptable. 